### PR TITLE
Nuxeo mapper now maps to 'temporal' not 'temporalCoverage'

### DIFF
--- a/lib/mappers/ucldc_nuxeo_mapper.py
+++ b/lib/mappers/ucldc_nuxeo_mapper.py
@@ -212,7 +212,7 @@ class UCLDCNuxeoMapper(Mapper):
 
     def map_temporal(self):
         if exists(self.provider_data_source, 'ucldc_schema:temporalcoverage'):
-            self.update_source_resource({'temporalCoverage': [tc for tc in self.provider_data_source.get('ucldc_schema:temporalcoverage')]})
+            self.update_source_resource({'temporal': [tc for tc in self.provider_data_source.get('ucldc_schema:temporalcoverage')]})
 
     def map_title(self):
         if exists(self.provider_data_source, 'dc:title'):

--- a/test/test_ucldc_nuxeo_mapper.py
+++ b/test/test_ucldc_nuxeo_mapper.py
@@ -44,7 +44,7 @@ def test_ucldc_nuxeo_mapping():
         TC.assertNotIn('relation', srcRes)
         TC.assertEqual(srcRes['rights'], ["Copyrighted", "This material is provided for private study, scholarship, or research. Transmission or reproduction of any material protected by copyright beyond that allowed by fair use requires the written permission of the copyright owners. The creators of the material or their heirs may retain copyright to this material."])
         TC.assertEqual(srcRes['subject'], ["Photographers -- Photographs"])
-        TC.assertEqual(srcRes['temporalCoverage'], [])
+        TC.assertEqual(srcRes['temporal'], [])
         TC.assertEqual(srcRes['title'],
                 [u"Adeline Cochems having her portrait taken by her father Edward W, Cochems in Santa Ana, California: Photograph"])
         TC.assertEqual(srcRes['type'], "image")


### PR DESCRIPTION
the mapper from couchdb => solr doesn't recognize the field `sourceResource['temporalCoverage']` but does recognize the field `sourceResource['temporal']`